### PR TITLE
feat: D4 꽃다발 빌더 UI 구현

### DIFF
--- a/devlog/DAY3.md
+++ b/devlog/DAY3.md
@@ -1,0 +1,133 @@
+# DAY 3 — 꽃집 상세 + 꽃 상세 모달 + 디자인 시스템
+
+> 2026-04-22
+
+---
+
+## 오늘 한 것
+
+- S-02 꽃집 상세 Bottom Sheet 구현 (`ShopDetailSheet.tsx`)
+- S-03 꽃 상세 모달 구현 (`FlowerDetailModal.tsx`)
+- 영업중 / 마감 실시간 판별 로직 (`isOpen` 함수)
+- 디자인 토큰 CSS 변수 정의 (`--rose`, `--ink`, `--muted` 등)
+- 꽃집 → 꽃 카드 탭 → 꽃 상세 모달 → 빌더 추가 흐름 연결
+
+---
+
+## 트러블슈팅
+
+### 1. 모달 배경 클릭 시 카드 클릭도 같이 발동
+
+모달 바깥 배경을 클릭해서 닫으려 했더니, 배경 `onClick`과 카드 `onClick`이 동시에 실행됨.
+
+**원인:** 이벤트 버블링. 자식 요소 클릭 이벤트가 부모까지 올라감.  
+**해결:** 모달 카드에 `e.stopPropagation()` 추가
+
+```tsx
+<div onClick={e => e.stopPropagation()}>
+  {/* 모달 내용 */}
+</div>
+```
+
+---
+
+### 2. `filter`로 undefined 제거할 때 타입 에러
+
+```ts
+const shopFlowers = shop.flowerIds
+  .map(id => flowers.find(f => f.id === id))
+  .filter(f => f !== undefined); // ❌ 타입이 여전히 (Flower | undefined)[]
+```
+
+**원인:** TypeScript는 `filter`만으로는 타입을 좁혀주지 않음.  
+**해결:** 타입 가드 함수로 명시
+
+```ts
+.filter((f): f is Flower => f !== undefined) // ✅ Flower[]
+```
+
+---
+
+## 오늘 배운 개념
+
+### 이벤트 버블링과 stopPropagation
+
+DOM 이벤트는 발생한 요소에서 시작해서 부모 방향으로 계속 전달됨 (버블링).
+
+```
+클릭 발생 → 자식 → 부모 → 조상 → document
+```
+
+`e.stopPropagation()`은 이 전파를 그 자리에서 막음.  
+모달, 드롭다운, Bottom Sheet처럼 "바깥 클릭으로 닫기" 패턴에서 필수.
+
+---
+
+### CSS 커스텀 프로퍼티 (디자인 토큰)
+
+```css
+:root {
+  --rose: #d4637a;
+  --ink: #1e1218;
+  --muted: #9a7580;
+}
+```
+
+색상, 폰트, 간격을 변수로 선언해두면:
+- 디자인 변경 시 한 곳만 수정하면 전체 반영
+- 컴포넌트마다 색상 코드 하드코딩 안 해도 됨
+- 포트폴리오에서 "디자인 시스템 설계" 어필 포인트
+
+```tsx
+// 컴포넌트에서
+color: 'var(--rose)'
+background: 'var(--rose-light)'
+```
+
+---
+
+### TypeScript 타입 가드 (Type Guard)
+
+TypeScript가 스스로 타입을 좁히지 못할 때, 직접 "이 값은 이 타입이다"를 보장해주는 함수.
+
+```ts
+// 일반 filter — 타입 그대로
+.filter(f => f !== undefined)  // (Flower | undefined)[]
+
+// 타입 가드 — 컴파일러가 타입 좁힘
+.filter((f): f is Flower => f !== undefined)  // Flower[]
+```
+
+`(f): f is Flower` 형태가 타입 가드 문법.  
+배열에서 `undefined` / `null` 걸러낼 때 자주 씀.
+
+---
+
+### Record<K, V> 유틸리티 타입
+
+특정 키 목록에 대해 값을 매핑하는 객체 타입을 간결하게 정의.
+
+```ts
+// 직접 쓰면 장황함
+type ColorMap = {
+  red: { bg: string; text: string; label: string };
+  pink: { bg: string; text: string; label: string };
+  // ... 8개 전부
+}
+
+// Record로 간결하게
+const COLOR_MAP: Record<ColorTag, { bg: string; text: string; label: string }> = {
+  red: { bg: '#fde8e8', text: '#c04060', label: '레드' },
+  // ...
+}
+```
+
+`ColorTag`의 모든 키를 빠짐없이 정의해야 컴파일 통과 → 실수로 빠뜨리는 것 방지.
+
+---
+
+## 내일 할 것 (D4)
+
+- S-04 꽃다발 빌더 화면
+- 꽃 선택 팔레트 + 미리보기 + 수량 조절 + 포장 옵션
+- builderStore UI 연결

--- a/devlog/DAY4.md
+++ b/devlog/DAY4.md
@@ -1,0 +1,101 @@
+# DAY 4 — 꽃다발 빌더 (핵심 UX)
+
+> 2026-04-23
+
+---
+
+## 오늘 한 것
+
+- S-04 꽃다발 빌더 전체 화면 구현 (`BuilderScreen.tsx`)
+- 꽃 선택 팔레트 — 색상 필터 + 15종 그리드 (`FlowerPalette.tsx`)
+- 현재 구성 미리보기 — 수량 +/- 조절, 소계 표시 (`BouquetPreview.tsx`)
+- 포장 옵션 선택 3종 (`WrapOptionSelector.tsx`)
+- `mapStore`에 `'builder'` 스크린 타입 추가 및 `App.tsx` 라우팅 연결
+- 꽃 상세 모달 → "빌더에 추가" 클릭 시 빌더 화면으로 자동 이동
+
+---
+
+## 트러블슈팅
+
+### 특별한 에러 없음
+
+`npx tsc --noEmit` 통과. 컴포넌트 분리와 store 연결이 설계대로 맞아떨어진 날.
+
+---
+
+## 오늘 배운 개념
+
+### Zustand selector로 리렌더 최적화
+
+Zustand 스토어 전체를 구독하면, 관련 없는 값이 바뀌어도 해당 컴포넌트가 리렌더됨.
+
+```ts
+// ❌ store 전체 구독 — wrapOption 바뀌어도 flowers 쓰는 컴포넌트가 리렌더
+const store = useBuilderStore();
+
+// ✅ 필요한 값만 구독 — flowers 바뀔 때만 리렌더
+const flowers = useBuilderStore(s => s.flowers);
+```
+
+오늘 만든 모든 컴포넌트에서 `s => s.flowers` 패턴을 사용한 이유.  
+React는 참조가 바뀌면 리렌더하기 때문에, 구독 범위를 좁히는 게 기본 습관.
+
+---
+
+### 파생 상태(Derived State)는 render에서 계산
+
+다른 state로부터 계산 가능한 값은 `useState`로 따로 관리하지 않음.
+
+```ts
+// ❌ 이렇게 하면 flowers 바뀔 때마다 total도 직접 업데이트해야 함 → 동기화 버그 위험
+const [total, setTotal] = useState(0);
+
+// ✅ render 중에 계산 — flowers만 관리하면 total은 항상 정확
+const total = flowers.reduce((sum, f) => sum + f.unitPrice * f.quantity, 0);
+```
+
+React 공식 문서도 강조하는 원칙: **"If you can calculate it during rendering, you don't need state."**
+
+---
+
+### Set으로 O(1) 조회
+
+꽃 카드 15개를 렌더할 때마다 "이미 담긴 꽃인지" 확인해야 함.
+
+```ts
+// ❌ 카드마다 배열 전체 순회 — O(n * m)
+const inCart = flowers.find(f => f.flowerId === flower.id);
+
+// ✅ Set으로 한 번 만들어두고 O(1) 조회
+const addedIds = new Set(added.map(f => f.flowerId));
+const inCart = addedIds.has(flower.id);
+```
+
+리스트를 렌더링할 때 "포함 여부 체크"가 필요하면 Set을 먼저 떠올리기.
+
+---
+
+### disabled 버튼과 UX
+
+꽃이 0개일 때 "요약 보기" 버튼을 그냥 막는 게 아니라, 이유를 알려주는 것이 중요.
+
+```tsx
+<button
+  disabled={flowers.length === 0}
+  style={{
+    background: flowers.length === 0 ? 'var(--border)' : 'var(--rose)',
+    cursor: flowers.length === 0 ? 'not-allowed' : 'pointer',
+  }}
+>
+  {flowers.length === 0 ? '꽃을 선택해주세요' : '요약 보기 →'}
+</button>
+```
+
+disabled 상태에서 텍스트, 색상, 커서까지 바꿔서 유저가 "왜 안 눌리지?"를 겪지 않게.
+
+---
+
+## 내일 할 것 (D5)
+
+- S-05 꽃다발 요약 화면 (선택 꽃 목록 · 예상 가격 · 메모 입력)
+- "요약 보기 →" 버튼과 실제 연결

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { useMapStore } from './store/mapStore';
 import MapScreen from './components/screens/MapScreen';
 import ListScreen from './components/screens/ListScreen';
 import SearchScreen from './components/screens/SearchScreen';
+import BuilderScreen from './components/screens/BuilderScreen';
 import ShopDetailSheet from './components/shop/ShopDetailSheet';
 
 export default function App() {
@@ -28,7 +29,8 @@ export default function App() {
       {screen === 'map' && <MapScreen />}
       {screen === 'list' && <ListScreen />}
       {screen === 'search' && <SearchScreen />}
-      {shopDetailId && <ShopDetailSheet />}
+      {screen === 'builder' && <BuilderScreen />}
+      {screen !== 'builder' && shopDetailId && <ShopDetailSheet />}
     </div>
   );
 }

--- a/src/components/builder/BouquetPreview.tsx
+++ b/src/components/builder/BouquetPreview.tsx
@@ -1,0 +1,112 @@
+import { useBuilderStore } from '../../store/builderStore';
+import type { ColorTag } from '../../types/flower';
+
+const FLOWER_EMOJI: Record<string, string> = {
+  'flower-01': '🌹', 'flower-02': '🌷', 'flower-03': '🌼',
+  'flower-04': '🪷', 'flower-05': '💐', 'flower-06': '🌻',
+  'flower-07': '🌸', 'flower-08': '💜', 'flower-09': '🤍',
+  'flower-10': '🌼', 'flower-11': '🌸', 'flower-12': '💙',
+  'flower-13': '🌿', 'flower-14': '💙', 'flower-15': '🌸',
+};
+
+const COLOR_DOT: Record<ColorTag, string> = {
+  red: '#c04060', pink: '#e07090', white: '#c0a8b0', yellow: '#c0a020',
+  purple: '#7c55b8', orange: '#c07020', blue: '#3a78a8', mixed: '#d4637a',
+};
+
+export default function BouquetPreview() {
+  const { flowers, updateQuantity, removeFlower } = useBuilderStore();
+
+  if (flowers.length === 0) {
+    return (
+      <div style={{
+        textAlign: 'center', padding: '28px 0',
+        border: '1.5px dashed var(--border)', borderRadius: 18,
+      }}>
+        <div style={{ fontSize: 36, marginBottom: 8 }}>💐</div>
+        <div style={{
+          fontFamily: 'var(--ff-kr)', fontSize: 13, color: 'var(--muted)',
+        }}>아래 팔레트에서 꽃을 골라보세요</div>
+      </div>
+    );
+  }
+
+  const total = flowers.reduce((sum, f) => sum + f.unitPrice * f.quantity, 0);
+
+  return (
+    <div style={{
+      border: '1.5px solid var(--border)', borderRadius: 18,
+      overflow: 'hidden', background: 'var(--white)',
+    }}>
+      {flowers.map((item, idx) => (
+        <div
+          key={item.flowerId}
+          style={{
+            display: 'flex', alignItems: 'center', gap: 12,
+            padding: '12px 14px',
+            borderBottom: idx < flowers.length - 1 ? '1px solid var(--border)' : 'none',
+          }}
+        >
+          <span style={{ fontSize: 24, flexShrink: 0 }}>
+            {FLOWER_EMOJI[item.flowerId] ?? '🌸'}
+          </span>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <span style={{
+                width: 8, height: 8, borderRadius: '50%', flexShrink: 0,
+                background: COLOR_DOT[item.color as ColorTag] ?? '#d4637a',
+              }} />
+              <span style={{
+                fontFamily: 'var(--ff-kr)', fontSize: 14, fontWeight: 700,
+                color: 'var(--ink)', letterSpacing: '-0.3px',
+              }}>{item.name}</span>
+            </div>
+            <span style={{
+              fontFamily: 'var(--ff-en)', fontSize: 11, color: 'var(--muted)',
+            }}>₩{(item.unitPrice * item.quantity).toLocaleString()}</span>
+          </div>
+
+          {/* 수량 조절 */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <button
+              onClick={() => {
+                if (item.quantity <= 1) removeFlower(item.flowerId);
+                else updateQuantity(item.flowerId, item.quantity - 1);
+              }}
+              style={qtyBtnStyle}
+            >−</button>
+            <span style={{
+              fontFamily: 'var(--ff-en)', fontSize: 14, fontWeight: 700,
+              color: 'var(--ink)', minWidth: 16, textAlign: 'center',
+            }}>{item.quantity}</span>
+            <button
+              onClick={() => updateQuantity(item.flowerId, item.quantity + 1)}
+              style={{ ...qtyBtnStyle, background: 'var(--rose)', color: '#fff', borderColor: 'var(--rose)' }}
+            >+</button>
+          </div>
+        </div>
+      ))}
+
+      {/* 소계 */}
+      <div style={{
+        padding: '12px 14px', background: 'var(--rose-light)',
+        display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+      }}>
+        <span style={{ fontFamily: 'var(--ff-kr)', fontSize: 12, color: 'var(--muted)' }}>
+          꽃 {flowers.reduce((s, f) => s + f.quantity, 0)}송이 기준 예상금액
+        </span>
+        <span style={{
+          fontFamily: 'var(--ff-en)', fontSize: 15, fontWeight: 700, color: 'var(--rose)',
+        }}>₩{total.toLocaleString()}</span>
+      </div>
+    </div>
+  );
+}
+
+const qtyBtnStyle: React.CSSProperties = {
+  width: 28, height: 28, borderRadius: 8,
+  border: '1.5px solid var(--border)',
+  background: 'var(--white)', color: 'var(--ink2)',
+  fontFamily: 'var(--ff-en)', fontSize: 16, fontWeight: 700,
+  cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center',
+};

--- a/src/components/builder/FlowerPalette.tsx
+++ b/src/components/builder/FlowerPalette.tsx
@@ -1,0 +1,127 @@
+import { useState } from 'react';
+import flowersData from '../../data/flowers.json';
+import type { Flower, ColorTag } from '../../types/flower';
+import { useBuilderStore } from '../../store/builderStore';
+
+const COLOR_META: Record<ColorTag | 'all', { label: string; dot: string }> = {
+  all:    { label: '전체',   dot: '#d4637a' },
+  red:    { label: '레드',   dot: '#c04060' },
+  pink:   { label: '핑크',   dot: '#e07090' },
+  white:  { label: '화이트', dot: '#c0a8b0' },
+  yellow: { label: '옐로우', dot: '#c0a020' },
+  purple: { label: '퍼플',   dot: '#7c55b8' },
+  orange: { label: '오렌지', dot: '#c07020' },
+  blue:   { label: '블루',   dot: '#3a78a8' },
+  mixed:  { label: '혼합',   dot: '#d4637a' },
+};
+
+const FLOWER_EMOJI: Record<string, string> = {
+  'flower-01': '🌹', 'flower-02': '🌷', 'flower-03': '🌼',
+  'flower-04': '🪷', 'flower-05': '💐', 'flower-06': '🌻',
+  'flower-07': '🌸', 'flower-08': '💜', 'flower-09': '🤍',
+  'flower-10': '🌼', 'flower-11': '🌸', 'flower-12': '💙',
+  'flower-13': '🌿', 'flower-14': '💙', 'flower-15': '🌸',
+};
+
+const flowers = flowersData as Flower[];
+const COLOR_FILTERS = ['all', 'red', 'pink', 'white', 'yellow', 'purple', 'orange', 'blue', 'mixed'] as const;
+
+export default function FlowerPalette() {
+  const [activeColor, setActiveColor] = useState<'all' | ColorTag>('all');
+  const { flowers: added, addFlower } = useBuilderStore();
+
+  const addedIds = new Set(added.map(f => f.flowerId));
+
+  const filtered = activeColor === 'all'
+    ? flowers
+    : flowers.filter(f => f.color === activeColor);
+
+  function handleAdd(flower: Flower) {
+    addFlower({
+      flowerId: flower.id,
+      name: flower.name,
+      quantity: 1,
+      color: flower.color,
+      unitPrice: flower.priceRange.min,
+    });
+  }
+
+  return (
+    <div>
+      {/* 색상 필터 */}
+      <div style={{
+        display: 'flex', gap: 8, overflowX: 'auto', paddingBottom: 4,
+        scrollbarWidth: 'none', marginBottom: 14,
+      }}>
+        {COLOR_FILTERS.map(c => {
+          const meta = COLOR_META[c];
+          const active = activeColor === c;
+          return (
+            <button
+              key={c}
+              onClick={() => setActiveColor(c)}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 5,
+                padding: '6px 12px', borderRadius: 100, border: 'none',
+                background: active ? 'var(--rose)' : 'var(--white)',
+                color: active ? '#fff' : 'var(--ink2)',
+                fontFamily: 'var(--ff-kr)', fontSize: 12, fontWeight: 600,
+                cursor: 'pointer', whiteSpace: 'nowrap',
+                boxShadow: active ? 'none' : '0 0 0 1.5px var(--border)',
+                flexShrink: 0,
+              }}
+            >
+              {c !== 'all' && (
+                <span style={{
+                  width: 8, height: 8, borderRadius: '50%',
+                  background: meta.dot, flexShrink: 0,
+                }} />
+              )}
+              {meta.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* 꽃 그리드 */}
+      <div style={{
+        display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 10,
+      }}>
+        {filtered.map(flower => {
+          const inCart = addedIds.has(flower.id);
+          return (
+            <button
+              key={flower.id}
+              onClick={() => handleAdd(flower)}
+              style={{
+                background: inCart ? 'var(--rose-light)' : 'var(--white)',
+                border: inCart ? '2px solid var(--rose)' : '1.5px solid var(--border)',
+                borderRadius: 16, padding: '12px 8px',
+                display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6,
+                cursor: 'pointer', position: 'relative',
+              }}
+            >
+              {inCart && (
+                <span style={{
+                  position: 'absolute', top: 6, right: 6,
+                  width: 16, height: 16, borderRadius: '50%',
+                  background: 'var(--rose)', color: '#fff',
+                  fontSize: 9, fontWeight: 700,
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                }}>✓</span>
+              )}
+              <span style={{ fontSize: 30 }}>{FLOWER_EMOJI[flower.id] ?? '🌸'}</span>
+              <span style={{
+                fontFamily: 'var(--ff-kr)', fontSize: 12, fontWeight: 700,
+                color: 'var(--ink)', letterSpacing: '-0.3px',
+              }}>{flower.name}</span>
+              <span style={{
+                fontFamily: 'var(--ff-en)', fontSize: 10, color: 'var(--muted)',
+              }}>₩{flower.priceRange.min.toLocaleString()}~</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/builder/WrapOptionSelector.tsx
+++ b/src/components/builder/WrapOptionSelector.tsx
@@ -1,0 +1,66 @@
+import { useBuilderStore } from '../../store/builderStore';
+
+const WRAP_OPTIONS = [
+  {
+    id: 'basic' as const,
+    emoji: '🧻',
+    label: '베이직',
+    desc: '자연스러운 크라프트지',
+    extra: '',
+  },
+  {
+    id: 'ribbon' as const,
+    emoji: '🎀',
+    label: '리본',
+    desc: '새틴 리본 마감',
+    extra: '+₩2,000',
+  },
+  {
+    id: 'premium' as const,
+    emoji: '✨',
+    label: '프리미엄',
+    desc: '고급 한지 + 리본',
+    extra: '+₩5,000',
+  },
+];
+
+export default function WrapOptionSelector() {
+  const { wrapOption, setWrapOption } = useBuilderStore();
+
+  return (
+    <div style={{ display: 'flex', gap: 10 }}>
+      {WRAP_OPTIONS.map(opt => {
+        const active = wrapOption === opt.id;
+        return (
+          <button
+            key={opt.id}
+            onClick={() => setWrapOption(opt.id)}
+            style={{
+              flex: 1, padding: '14px 8px', borderRadius: 16,
+              border: active ? '2px solid var(--rose)' : '1.5px solid var(--border)',
+              background: active ? 'var(--rose-light)' : 'var(--white)',
+              cursor: 'pointer', textAlign: 'center',
+            }}
+          >
+            <div style={{ fontSize: 24, marginBottom: 6 }}>{opt.emoji}</div>
+            <div style={{
+              fontFamily: 'var(--ff-kr)', fontSize: 13, fontWeight: 700,
+              color: active ? 'var(--rose)' : 'var(--ink)',
+              marginBottom: 3, letterSpacing: '-0.3px',
+            }}>{opt.label}</div>
+            <div style={{
+              fontFamily: 'var(--ff-kr)', fontSize: 10,
+              color: 'var(--muted)', marginBottom: 4,
+            }}>{opt.desc}</div>
+            {opt.extra && (
+              <div style={{
+                fontFamily: 'var(--ff-en)', fontSize: 11, fontWeight: 700,
+                color: active ? 'var(--rose)' : 'var(--ink2)',
+              }}>{opt.extra}</div>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/flower/FlowerDetailModal.tsx
+++ b/src/components/flower/FlowerDetailModal.tsx
@@ -1,5 +1,6 @@
 import type { Flower, ColorTag } from '../../types/flower';
 import { useBuilderStore } from '../../store/builderStore';
+import { useMapStore } from '../../store/mapStore';
 
 interface Props {
   flower: Flower;
@@ -31,6 +32,7 @@ const SEASON_KR: Record<string, string> = {
 
 export default function FlowerDetailModal({ flower, onClose }: Props) {
   const addFlower = useBuilderStore(s => s.addFlower);
+  const setScreen = useMapStore(s => s.setScreen);
   const color = COLOR_MAP[flower.color];
   const emoji = FLOWER_EMOJI[flower.id] ?? '🌸';
 
@@ -43,6 +45,7 @@ export default function FlowerDetailModal({ flower, onClose }: Props) {
       unitPrice: flower.priceRange.min,
     });
     onClose();
+    setScreen('builder');
   }
 
   return (

--- a/src/components/screens/BuilderScreen.tsx
+++ b/src/components/screens/BuilderScreen.tsx
@@ -1,0 +1,117 @@
+import { useMapStore } from '../../store/mapStore';
+import { useBuilderStore } from '../../store/builderStore';
+import BouquetPreview from '../builder/BouquetPreview';
+import FlowerPalette from '../builder/FlowerPalette';
+import WrapOptionSelector from '../builder/WrapOptionSelector';
+
+const WRAP_EXTRA: Record<string, number> = { basic: 0, ribbon: 2000, premium: 5000 };
+
+export default function BuilderScreen() {
+  const setScreen = useMapStore(s => s.setScreen);
+  const { flowers, wrapOption } = useBuilderStore();
+
+  const flowerTotal = flowers.reduce((sum, f) => sum + f.unitPrice * f.quantity, 0);
+  const total = flowerTotal + WRAP_EXTRA[wrapOption];
+  const count = flowers.reduce((s, f) => s + f.quantity, 0);
+
+  return (
+    <div style={{
+      width: '100%', height: '100dvh', display: 'flex', flexDirection: 'column',
+      background: '#faf6f7',
+    }}>
+      {/* 헤더 */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 12,
+        padding: '16px 20px 12px', background: 'var(--white)',
+        borderBottom: '1px solid var(--border)', flexShrink: 0,
+      }}>
+        <button
+          onClick={() => setScreen('map')}
+          style={{
+            width: 36, height: 36, borderRadius: 10,
+            border: '1.5px solid var(--border)', background: 'transparent',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            cursor: 'pointer', fontSize: 18, color: 'var(--ink2)',
+          }}
+        >←</button>
+        <div style={{ flex: 1 }}>
+          <div style={{
+            fontFamily: 'var(--ff-kr)', fontSize: 17, fontWeight: 700,
+            color: 'var(--ink)', letterSpacing: '-0.5px',
+          }}>꽃다발 빌더</div>
+        </div>
+        {count > 0 && (
+          <span style={{
+            background: 'var(--rose)', color: '#fff',
+            borderRadius: 100, padding: '3px 10px',
+            fontFamily: 'var(--ff-kr)', fontSize: 12, fontWeight: 700,
+          }}>{count}송이</span>
+        )}
+      </div>
+
+      {/* 스크롤 영역 */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: '20px 20px 0' }}>
+        {/* 현재 구성 */}
+        <div style={{ marginBottom: 24 }}>
+          <SectionTitle>현재 구성</SectionTitle>
+          <BouquetPreview />
+        </div>
+
+        {/* 포장 선택 */}
+        <div style={{ marginBottom: 24 }}>
+          <SectionTitle>포장 선택</SectionTitle>
+          <WrapOptionSelector />
+        </div>
+
+        {/* 꽃 추가 */}
+        <div style={{ marginBottom: 24 }}>
+          <SectionTitle>꽃 추가하기</SectionTitle>
+          <FlowerPalette />
+        </div>
+
+        <div style={{ height: 100 }} />
+      </div>
+
+      {/* 하단 CTA */}
+      <div style={{
+        padding: '12px 20px 24px', background: 'var(--white)',
+        borderTop: '1px solid var(--border)', flexShrink: 0,
+      }}>
+        <div style={{
+          display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+          marginBottom: 12,
+        }}>
+          <span style={{ fontFamily: 'var(--ff-kr)', fontSize: 13, color: 'var(--muted)' }}>
+            포장 포함 예상금액
+          </span>
+          <span style={{
+            fontFamily: 'var(--ff-en)', fontSize: 18, fontWeight: 700, color: 'var(--ink)',
+          }}>₩{total.toLocaleString()}</span>
+        </div>
+        <button
+          disabled={flowers.length === 0}
+          onClick={() => setScreen('map')}
+          style={{
+            width: '100%', padding: '15px 0',
+            background: flowers.length === 0 ? 'var(--border)' : 'var(--rose)',
+            color: flowers.length === 0 ? 'var(--muted)' : '#fff',
+            border: 'none', borderRadius: 16,
+            fontFamily: 'var(--ff-kr)', fontSize: 16, fontWeight: 700,
+            letterSpacing: '-0.3px', cursor: flowers.length === 0 ? 'not-allowed' : 'pointer',
+          }}
+        >
+          {flowers.length === 0 ? '꽃을 선택해주세요' : '요약 보기 →'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{
+      fontFamily: 'var(--ff-kr)', fontSize: 13, fontWeight: 700,
+      color: 'var(--muted)', letterSpacing: '-0.2px', marginBottom: 10,
+    }}>{children}</div>
+  );
+}

--- a/src/store/mapStore.ts
+++ b/src/store/mapStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-export type Screen = 'map' | 'list' | 'search';
+export type Screen = 'map' | 'list' | 'search' | 'builder';
 
 interface MapStore {
   screen: Screen;


### PR DESCRIPTION
## Summary
- 꽃 선택 팔레트 (색상 필터 + 15종 그리드)
- 현재 구성 미리보기 (수량 +/- 조절, 소계)
- 포장 옵션 선택 3종 (베이직/리본/프리미엄)
- 빌더 전체 화면 및 라우팅 연결
- 꽃 상세 모달 → 빌더 자동 이동

Closes #4