### PR TITLE
feat: D5 S-05 요약 + S-06 꽃집 연결 + AI 추천 + 로그 연동

### DIFF
--- a/scripts/test-ai-recommend.mjs
+++ b/scripts/test-ai-recommend.mjs
@@ -1,0 +1,69 @@
+/**
+ * 꽃 추천 AI 테스트 (Groq)
+ * 실행: node --env-file=.env scripts/test-ai-recommend.mjs
+ */
+
+const PROMPT = `당신은 꽃다발 전문 플로리스트입니다. 아래 조건에 맞는 꽃 3가지를 추천해주세요.
+
+상황: 생일 선물
+선호 색상: 핑크, 화이트
+예산: ₩30,000 이하
+
+꽃 목록: flower-01(장미/레드), flower-02(튤립/핑크), flower-03(국화/화이트), flower-04(연꽃/퍼플), flower-05(혼합부케/혼합), flower-06(해바라기/옐로우), flower-07(벚꽃/핑크), flower-08(라벤더/퍼플), flower-09(카네이션/화이트), flower-10(데이지/화이트), flower-11(수국/핑크), flower-12(델피늄/블루), flower-13(유칼립투스/혼합), flower-14(수레국화/블루), flower-15(철쭉/핑크)
+
+반드시 아래 JSON 형식으로만 응답하세요. 다른 텍스트는 절대 포함하지 마세요:
+{"message":"한 문장 추천 이유","flowerIds":["flower-xx","flower-xx","flower-xx"]}`;
+
+async function testGroq() {
+  const key = process.env.GROQ_API_KEY;
+  if (!key) return { error: 'GROQ_API_KEY 없음' };
+
+  const start = Date.now();
+  const res = await fetch('https://api.groq.com/openai/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${key}`,
+    },
+    body: JSON.stringify({
+      model: 'llama-3.1-8b-instant',
+      max_tokens: 256,
+      response_format: { type: 'json_object' },
+      messages: [{ role: 'user', content: PROMPT }],
+    }),
+  });
+  const ms = Date.now() - start;
+  const data = await res.json();
+  if (!res.ok) return { error: data.error?.message ?? res.status, ms };
+
+  const text = data.choices[0].message.content.trim();
+  const inputTokens = data.usage?.prompt_tokens ?? 0;
+  const outputTokens = data.usage?.completion_tokens ?? 0;
+  return { ms, text, inputTokens, outputTokens };
+}
+
+async function main() {
+  console.log('🌸 Groq (Llama 3.1) 꽃 추천 테스트\n');
+
+  const r = await testGroq();
+
+  if (r.error) {
+    console.log(`❌ 오류: ${r.error}`);
+    return;
+  }
+
+  console.log(`⏱  응답시간: ${r.ms}ms`);
+  console.log(`🪙 토큰: input ${r.inputTokens} / output ${r.outputTokens} (무료)`);
+
+  try {
+    const parsed = JSON.parse(r.text);
+    console.log(`\n✅ JSON 유효`);
+    console.log(`💬 추천 이유: ${parsed.message}`);
+    console.log(`🌸 추천 꽃:   ${parsed.flowerIds?.join(', ')}`);
+  } catch {
+    console.log(`⚠️  JSON 파싱 실패`);
+    console.log(`Raw: ${r.text.slice(0, 200)}`);
+  }
+}
+
+main().catch(console.error);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import MapScreen from './components/screens/MapScreen';
 import ListScreen from './components/screens/ListScreen';
 import SearchScreen from './components/screens/SearchScreen';
 import BuilderScreen from './components/screens/BuilderScreen';
+import SummaryScreen from './components/screens/SummaryScreen';
 import ShopDetailSheet from './components/shop/ShopDetailSheet';
 
 export default function App() {
@@ -30,7 +31,8 @@ export default function App() {
       {screen === 'list' && <ListScreen />}
       {screen === 'search' && <SearchScreen />}
       {screen === 'builder' && <BuilderScreen />}
-      {screen !== 'builder' && shopDetailId && <ShopDetailSheet />}
+      {screen === 'summary' && <SummaryScreen />}
+      {screen !== 'builder' && screen !== 'summary' && shopDetailId && <ShopDetailSheet />}
     </div>
   );
 }

--- a/src/api/groq.ts
+++ b/src/api/groq.ts
@@ -1,0 +1,51 @@
+import type { ColorTag } from '../types/flower';
+
+interface RecommendParams {
+  occasion: string;
+  colors: ColorTag[];
+  budget: number;
+}
+
+export interface RecommendResult {
+  message: string;
+  flowerIds: string[];
+}
+
+export async function getFlowerRecommendation(params: RecommendParams): Promise<RecommendResult> {
+  const apiKey = import.meta.env.VITE_GROQ_API_KEY;
+  if (!apiKey) throw new Error('VITE_GROQ_API_KEY not set');
+
+  const prompt = `당신은 꽃다발 전문 플로리스트입니다. 아래 조건에 맞는 꽃 3가지를 추천해주세요.
+
+상황: ${params.occasion}
+선호 색상: ${params.colors.length > 0 ? params.colors.join(', ') : '제한 없음'}
+예산: ₩${params.budget.toLocaleString()} 이하
+
+꽃 목록 ID: flower-01(장미/레드), flower-02(튤립/핑크), flower-03(국화/화이트), flower-04(연꽃/퍼플), flower-05(혼합부케/혼합), flower-06(해바라기/옐로우), flower-07(벚꽃/핑크), flower-08(라벤더/퍼플), flower-09(카네이션/화이트), flower-10(데이지/화이트), flower-11(수국/핑크), flower-12(델피늄/블루), flower-13(유칼립투스/혼합), flower-14(수레국화/블루), flower-15(철쭉/핑크)
+
+반드시 아래 JSON 형식으로만 응답하세요. 다른 텍스트는 절대 포함하지 마세요:
+{"message":"한 문장 추천 이유","flowerIds":["flower-xx","flower-xx","flower-xx"]}`;
+
+  const res = await fetch('https://api.groq.com/openai/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: 'llama-3.1-8b-instant',
+      max_tokens: 256,
+      response_format: { type: 'json_object' },
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  });
+
+  if (!res.ok) {
+    const err = await res.json();
+    throw new Error(err.error?.message ?? `Groq API error: ${res.status}`);
+  }
+
+  const data = await res.json();
+  const text = data.choices[0].message.content.trim();
+  return JSON.parse(text) as RecommendResult;
+}

--- a/src/components/builder/BouquetPreview.tsx
+++ b/src/components/builder/BouquetPreview.tsx
@@ -1,4 +1,5 @@
 import { useBuilderStore } from '../../store/builderStore';
+import { useAnalytics } from '../../hooks/useAnalytics';
 import type { ColorTag } from '../../types/flower';
 
 const FLOWER_EMOJI: Record<string, string> = {
@@ -15,6 +16,7 @@ const COLOR_DOT: Record<ColorTag, string> = {
 };
 
 export default function BouquetPreview() {
+  const { track } = useAnalytics();
   const { flowers, updateQuantity, removeFlower } = useBuilderStore();
 
   if (flowers.length === 0) {
@@ -70,8 +72,8 @@ export default function BouquetPreview() {
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
             <button
               onClick={() => {
-                if (item.quantity <= 1) removeFlower(item.flowerId);
-                else updateQuantity(item.flowerId, item.quantity - 1);
+                if (item.quantity <= 1) { removeFlower(item.flowerId); track('flower_removed', { flowerId: item.flowerId }); }
+                else { updateQuantity(item.flowerId, item.quantity - 1); track('qty_changed', { flowerId: item.flowerId, qty: item.quantity - 1 }); }
               }}
               style={qtyBtnStyle}
             >−</button>
@@ -80,7 +82,7 @@ export default function BouquetPreview() {
               color: 'var(--ink)', minWidth: 16, textAlign: 'center',
             }}>{item.quantity}</span>
             <button
-              onClick={() => updateQuantity(item.flowerId, item.quantity + 1)}
+              onClick={() => { updateQuantity(item.flowerId, item.quantity + 1); track('qty_changed', { flowerId: item.flowerId, qty: item.quantity + 1 }); }}
               style={{ ...qtyBtnStyle, background: 'var(--rose)', color: '#fff', borderColor: 'var(--rose)' }}
             >+</button>
           </div>

--- a/src/components/builder/FlowerPalette.tsx
+++ b/src/components/builder/FlowerPalette.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import flowersData from '../../data/flowers.json';
 import type { Flower, ColorTag } from '../../types/flower';
 import { useBuilderStore } from '../../store/builderStore';
+import { useAnalytics } from '../../hooks/useAnalytics';
 
 const COLOR_META: Record<ColorTag | 'all', { label: string; dot: string }> = {
   all:    { label: '전체',   dot: '#d4637a' },
@@ -27,6 +28,7 @@ const flowers = flowersData as Flower[];
 const COLOR_FILTERS = ['all', 'red', 'pink', 'white', 'yellow', 'purple', 'orange', 'blue', 'mixed'] as const;
 
 export default function FlowerPalette() {
+  const { track } = useAnalytics();
   const [activeColor, setActiveColor] = useState<'all' | ColorTag>('all');
   const { flowers: added, addFlower } = useBuilderStore();
 
@@ -44,6 +46,7 @@ export default function FlowerPalette() {
       color: flower.color,
       unitPrice: flower.priceRange.min,
     });
+    track('flower_added', { flowerId: flower.id });
   }
 
   return (

--- a/src/components/builder/WrapOptionSelector.tsx
+++ b/src/components/builder/WrapOptionSelector.tsx
@@ -1,4 +1,5 @@
 import { useBuilderStore } from '../../store/builderStore';
+import { useAnalytics } from '../../hooks/useAnalytics';
 
 const WRAP_OPTIONS = [
   {
@@ -25,6 +26,7 @@ const WRAP_OPTIONS = [
 ];
 
 export default function WrapOptionSelector() {
+  const { track } = useAnalytics();
   const { wrapOption, setWrapOption } = useBuilderStore();
 
   return (
@@ -34,7 +36,7 @@ export default function WrapOptionSelector() {
         return (
           <button
             key={opt.id}
-            onClick={() => setWrapOption(opt.id)}
+            onClick={() => { setWrapOption(opt.id); track('wrap_option_selected', { option: opt.id }); }}
             style={{
               flex: 1, padding: '14px 8px', borderRadius: 16,
               border: active ? '2px solid var(--rose)' : '1.5px solid var(--border)',

--- a/src/components/screens/BuilderScreen.tsx
+++ b/src/components/screens/BuilderScreen.tsx
@@ -1,18 +1,86 @@
+import { useState, useEffect } from 'react';
 import { useMapStore } from '../../store/mapStore';
 import { useBuilderStore } from '../../store/builderStore';
 import BouquetPreview from '../builder/BouquetPreview';
 import FlowerPalette from '../builder/FlowerPalette';
 import WrapOptionSelector from '../builder/WrapOptionSelector';
+import { getFlowerRecommendation } from '../../api/groq';
+import flowersData from '../../data/flowers.json';
+import type { ColorTag } from '../../types/flower';
 
 const WRAP_EXTRA: Record<string, number> = { basic: 0, ribbon: 2000, premium: 5000 };
 
+const COLOR_OPTIONS: { label: string; value: ColorTag }[] = [
+  { label: '레드', value: 'red' },
+  { label: '핑크', value: 'pink' },
+  { label: '화이트', value: 'white' },
+  { label: '옐로우', value: 'yellow' },
+  { label: '퍼플', value: 'purple' },
+  { label: '블루', value: 'blue' },
+  { label: '혼합', value: 'mixed' },
+];
+
 export default function BuilderScreen() {
   const setScreen = useMapStore(s => s.setScreen);
-  const { flowers, wrapOption } = useBuilderStore();
+  const builderOpenAi = useMapStore(s => s.builderOpenAi);
+  const resetBuilderOpenAi = useMapStore(s => s.resetBuilderOpenAi);
+  const { flowers, wrapOption, addFlower } = useBuilderStore();
+
+  const [showAi, setShowAi] = useState(builderOpenAi);
+
+  useEffect(() => {
+    if (builderOpenAi) resetBuilderOpenAi();
+  }, []);
+  const [occasion, setOccasion] = useState('');
+  const [selectedColors, setSelectedColors] = useState<ColorTag[]>([]);
+  const [budget, setBudget] = useState(30000);
+  const [loading, setLoading] = useState(false);
+  const [aiError, setAiError] = useState('');
 
   const flowerTotal = flowers.reduce((sum, f) => sum + f.unitPrice * f.quantity, 0);
   const total = flowerTotal + WRAP_EXTRA[wrapOption];
   const count = flowers.reduce((s, f) => s + f.quantity, 0);
+
+  const toggleColor = (color: ColorTag) => {
+    setSelectedColors(prev =>
+      prev.includes(color) ? prev.filter(c => c !== color) : [...prev, color]
+    );
+  };
+
+  const handleAiRecommend = async () => {
+    if (!occasion.trim()) {
+      setAiError('상황을 입력해주세요');
+      return;
+    }
+    setLoading(true);
+    setAiError('');
+    try {
+      const result = await getFlowerRecommendation({
+        occasion: occasion.trim(),
+        colors: selectedColors,
+        budget,
+      });
+      result.flowerIds.forEach(id => {
+        const flower = flowersData.find(f => f.id === id);
+        if (flower) {
+          addFlower({
+            flowerId: flower.id,
+            name: flower.name,
+            quantity: 1,
+            color: flower.color,
+            unitPrice: flower.priceRange.min,
+          });
+        }
+      });
+      setShowAi(false);
+      setOccasion('');
+      setSelectedColors([]);
+    } catch (e) {
+      setAiError(e instanceof Error ? e.message : '추천 실패. 다시 시도해주세요.');
+    } finally {
+      setLoading(false);
+    }
+  };
 
   return (
     <div style={{
@@ -63,9 +131,100 @@ export default function BuilderScreen() {
           <WrapOptionSelector />
         </div>
 
-        {/* 꽃 추가 */}
+        {/* 꽃 추가 + AI 추천 */}
         <div style={{ marginBottom: 24 }}>
-          <SectionTitle>꽃 추가하기</SectionTitle>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 }}>
+            <SectionTitle>꽃 추가하기</SectionTitle>
+            <button
+              onClick={() => { setShowAi(v => !v); setAiError(''); }}
+              style={{
+                display: 'flex', alignItems: 'center', gap: 4,
+                padding: '5px 12px', borderRadius: 20,
+                border: '1.5px solid var(--rose)',
+                background: showAi ? 'var(--rose)' : 'transparent',
+                color: showAi ? '#fff' : 'var(--rose)',
+                fontFamily: 'var(--ff-kr)', fontSize: 12, fontWeight: 700,
+                cursor: 'pointer',
+              }}
+            >🌸 AI 추천</button>
+          </div>
+
+          {/* AI 패널 */}
+          {showAi && (
+            <div style={{
+              background: 'var(--white)', borderRadius: 16,
+              border: '1.5px solid var(--border)', padding: 16, marginBottom: 16,
+            }}>
+              <div style={{ marginBottom: 12 }}>
+                <Label>어떤 상황인가요?</Label>
+                <input
+                  value={occasion}
+                  onChange={e => setOccasion(e.target.value)}
+                  placeholder="예: 생일 선물, 졸업 축하, 프로포즈"
+                  style={{
+                    width: '100%', padding: '10px 12px', borderRadius: 10,
+                    border: '1.5px solid var(--border)', background: '#faf6f7',
+                    fontFamily: 'var(--ff-kr)', fontSize: 14, color: 'var(--ink)',
+                    boxSizing: 'border-box', outline: 'none',
+                  }}
+                />
+              </div>
+
+              <div style={{ marginBottom: 12 }}>
+                <Label>선호 색상 (복수 선택 가능)</Label>
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                  {COLOR_OPTIONS.map(({ label, value }) => (
+                    <button
+                      key={value}
+                      onClick={() => toggleColor(value)}
+                      style={{
+                        padding: '5px 12px', borderRadius: 20, fontSize: 12,
+                        fontFamily: 'var(--ff-kr)', fontWeight: 600, cursor: 'pointer',
+                        border: '1.5px solid var(--border)',
+                        background: selectedColors.includes(value) ? 'var(--rose)' : 'transparent',
+                        color: selectedColors.includes(value) ? '#fff' : 'var(--ink2)',
+                      }}
+                    >{label}</button>
+                  ))}
+                </div>
+              </div>
+
+              <div style={{ marginBottom: 14 }}>
+                <Label>예산: ₩{budget.toLocaleString()}</Label>
+                <input
+                  type="range" min={10000} max={100000} step={5000}
+                  value={budget}
+                  onChange={e => setBudget(Number(e.target.value))}
+                  style={{ width: '100%', accentColor: 'var(--rose)' }}
+                />
+                <div style={{
+                  display: 'flex', justifyContent: 'space-between',
+                  fontFamily: 'var(--ff-kr)', fontSize: 11, color: 'var(--muted)',
+                }}>
+                  <span>₩10,000</span><span>₩100,000</span>
+                </div>
+              </div>
+
+              {aiError && (
+                <div style={{ color: '#e53e3e', fontFamily: 'var(--ff-kr)', fontSize: 12, marginBottom: 10 }}>
+                  {aiError}
+                </div>
+              )}
+
+              <button
+                onClick={handleAiRecommend}
+                disabled={loading}
+                style={{
+                  width: '100%', padding: '12px 0', borderRadius: 12,
+                  background: loading ? 'var(--border)' : 'var(--rose)',
+                  color: loading ? 'var(--muted)' : '#fff',
+                  border: 'none', fontFamily: 'var(--ff-kr)', fontSize: 14, fontWeight: 700,
+                  cursor: loading ? 'not-allowed' : 'pointer',
+                }}
+              >{loading ? '추천 중...' : '추천 받기'}</button>
+            </div>
+          )}
+
           <FlowerPalette />
         </div>
 
@@ -90,7 +249,7 @@ export default function BuilderScreen() {
         </div>
         <button
           disabled={flowers.length === 0}
-          onClick={() => setScreen('map')}
+          onClick={() => setScreen('summary')}
           style={{
             width: '100%', padding: '15px 0',
             background: flowers.length === 0 ? 'var(--border)' : 'var(--rose)',
@@ -111,7 +270,16 @@ function SectionTitle({ children }: { children: React.ReactNode }) {
   return (
     <div style={{
       fontFamily: 'var(--ff-kr)', fontSize: 13, fontWeight: 700,
-      color: 'var(--muted)', letterSpacing: '-0.2px', marginBottom: 10,
+      color: 'var(--muted)', letterSpacing: '-0.2px',
+    }}>{children}</div>
+  );
+}
+
+function Label({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{
+      fontFamily: 'var(--ff-kr)', fontSize: 12, fontWeight: 700,
+      color: 'var(--ink2)', marginBottom: 8,
     }}>{children}</div>
   );
 }

--- a/src/components/screens/ListScreen.tsx
+++ b/src/components/screens/ListScreen.tsx
@@ -1,4 +1,5 @@
 import { useMapStore } from '../../store/mapStore';
+import { useAnalytics } from '../../hooks/useAnalytics';
 import shopsData from '../../data/shops.json';
 import type { Shop } from '../../types/shop';
 
@@ -32,7 +33,8 @@ const pill = (selected: boolean, soft = false): React.CSSProperties => ({
 });
 
 export default function ListScreen() {
-  const { setScreen, setShopDetailId } = useMapStore();
+  const { setScreen, setShopDetailId, openBuilderWithAi } = useMapStore();
+  const { track } = useAnalytics();
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', width: '100%', height: '100dvh', background: '#faf6f7', overflow: 'hidden' }}>
@@ -136,7 +138,7 @@ export default function ListScreen() {
       {/* Shop list */}
       <div style={{ flex: 1, overflowY: 'auto', padding: '0 13px 12px' }}>
         {shops.map(shop => (
-          <div key={shop.id} onClick={() => setShopDetailId(shop.id)} style={{
+          <div key={shop.id} onClick={() => { setShopDetailId(shop.id); track('list_item_click', { shopId: shop.id }); }} style={{
             background: 'var(--white)', borderRadius: 16,
             border: '1.5px solid var(--border)', overflow: 'hidden', marginBottom: 10,
             cursor: 'pointer',
@@ -175,7 +177,9 @@ export default function ListScreen() {
                   <span key={t} style={{ ...pill(false), padding: '2px 9px', fontSize: 11 }}>{t}</span>
                 ))}
               </div>
-              <button style={{
+              <button
+                onClick={() => openBuilderWithAi()}
+                style={{
                 marginTop: 9, padding: '8px 0', width: '100%',
                 background: 'transparent', color: 'var(--rose)',
                 border: '1.5px solid var(--rose)', borderRadius: 13,

--- a/src/components/screens/MapScreen.tsx
+++ b/src/components/screens/MapScreen.tsx
@@ -1,11 +1,20 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Map, CustomOverlayMap } from 'react-kakao-maps-sdk';
 import { useMapStore } from '../../store/mapStore';
+import { useAnalytics } from '../../hooks/useAnalytics';
 import shopsData from '../../data/shops.json';
 import type { Shop } from '../../types/shop';
 
 const shops = shopsData as Shop[];
 const CATEGORIES = ['🌸 전체', '🌹 장미', '🌷 튤립', '💐 부케', '🤖 AI추천'];
+
+const CATEGORY_FILTER: ((shop: Shop) => boolean)[] = [
+  () => true,
+  (s) => s.flowerIds.includes('flower-01'),
+  (s) => s.flowerIds.includes('flower-02'),
+  (s) => s.tags.includes('부케'),
+  () => false,
+];
 
 const SearchIcon = () => (
   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--rose)" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
@@ -14,15 +23,26 @@ const SearchIcon = () => (
 );
 
 export default function MapScreen() {
-  const { mapCenter, setMapCenter, setSelectedShopId, setScreen, setShopDetailId } = useMapStore();
+  const { mapCenter, setMapCenter, setSelectedShopId, setScreen, setShopDetailId, openBuilderWithAi } = useMapStore();
+  const { track } = useAnalytics();
   const [selIdx, setSelIdx] = useState(0);
   const [selCat, setSelCat] = useState(0);
 
-  const selectedShop = shops[selIdx];
+  useEffect(() => { track('map_open'); }, []);
+
+  const filteredShops = shops.filter(CATEGORY_FILTER[selCat] ?? (() => true));
+  const selectedShop = filteredShops[selIdx] ?? filteredShops[0];
 
   function handleMarkerClick(i: number) {
     setSelIdx(i);
-    setSelectedShopId(shops[i].id);
+    setSelectedShopId(filteredShops[i].id);
+    track('marker_click', { shopId: filteredShops[i].id });
+  }
+
+  function handleCatSelect(i: number) {
+    if (i === 4) { openBuilderWithAi(); return; }
+    setSelCat(i);
+    setSelIdx(0);
   }
 
   return (
@@ -36,7 +56,7 @@ export default function MapScreen() {
           setMapCenter({ lat: map.getCenter().getLat(), lng: map.getCenter().getLng() })
         }
       >
-        {shops.map((shop, i) => (
+        {filteredShops.map((shop, i) => (
           <CustomOverlayMap
             key={shop.id}
             position={{ lat: shop.lat, lng: shop.lng }}
@@ -99,7 +119,7 @@ export default function MapScreen() {
           {CATEGORIES.map((c, i) => (
             <span
               key={c}
-              onClick={() => setSelCat(i)}
+              onClick={() => handleCatSelect(i)}
               style={{
                 display: 'inline-flex', alignItems: 'center', gap: 4,
                 borderRadius: 100, padding: '5px 12px',
@@ -132,7 +152,17 @@ export default function MapScreen() {
 
       {/* Bottom shop card */}
       <div style={{ position: 'absolute', bottom: 16, left: 14, right: 14, zIndex: 20 }}>
-        <div style={{
+        {filteredShops.length === 0 && (
+          <div style={{
+            background: 'var(--white)', borderRadius: 16,
+            border: '1.5px solid var(--border)', padding: '20px 14px',
+            boxShadow: '0 8px 24px rgba(0,0,0,0.12)',
+            textAlign: 'center', fontFamily: 'var(--ff-kr)', fontSize: 13, color: 'var(--muted)',
+          }}>
+            해당 꽃을 취급하는 주변 꽃집이 없어요 🌿
+          </div>
+        )}
+        {filteredShops.length > 0 && selectedShop && <div style={{
           background: 'var(--white)', borderRadius: 16,
           border: '1.5px solid var(--border)',
           padding: 14, boxShadow: '0 8px 24px rgba(0,0,0,0.12)',
@@ -170,7 +200,9 @@ export default function MapScreen() {
                     borderRadius: 13, padding: '8px 0', fontSize: 12,
                     fontFamily: 'var(--ff-kr)', fontWeight: 700, cursor: 'pointer',
                   }}>상세보기</button>
-                <button style={{
+                <button
+                  onClick={() => openBuilderWithAi()}
+                  style={{
                   flex: 1, background: 'transparent', color: 'var(--rose)',
                   border: '1.5px solid var(--rose)',
                   borderRadius: 13, padding: '7px 0', fontSize: 12,
@@ -181,7 +213,7 @@ export default function MapScreen() {
           </div>
           {/* Carousel dots */}
           <div style={{ display: 'flex', justifyContent: 'center', gap: 5, marginTop: 10 }}>
-            {shops.map((_, i) => (
+            {filteredShops.map((_, i) => (
               <div
                 key={i}
                 onClick={() => handleMarkerClick(i)}
@@ -193,7 +225,7 @@ export default function MapScreen() {
               />
             ))}
           </div>
-        </div>
+        </div>}
       </div>
     </div>
   );

--- a/src/components/screens/SearchScreen.tsx
+++ b/src/components/screens/SearchScreen.tsx
@@ -21,7 +21,7 @@ const pill = (selected: boolean, soft = false): React.CSSProperties => ({
 });
 
 export default function SearchScreen() {
-  const { setScreen } = useMapStore();
+  const { setScreen, openBuilderWithAi } = useMapStore();
   const [selFlowers, setSelFlowers] = useState<number[]>([0, 3]);
   const [selOccasions, setSelOccasions] = useState<number[]>([1]);
   const [selDist, setSelDist] = useState(1);
@@ -168,7 +168,9 @@ export default function SearchScreen() {
           <p style={{ fontFamily: 'var(--ff-kr)', fontSize: 12, color: 'var(--ink2)', lineHeight: 1.6, marginBottom: 10 }}>
             목적과 예산을 입력하면 AI가 최적의 꽃 조합을 찾아드려요 🌸
           </p>
-          <button style={{
+          <button
+            onClick={() => openBuilderWithAi()}
+            style={{
             width: '100%', padding: '10px 0',
             background: 'var(--rose)', color: '#fff', border: 'none',
             borderRadius: 13, fontFamily: 'var(--ff-kr)',

--- a/src/components/screens/SummaryScreen.tsx
+++ b/src/components/screens/SummaryScreen.tsx
@@ -1,0 +1,224 @@
+import { useState, useEffect } from 'react';
+import { useMapStore } from '../../store/mapStore';
+import { useBuilderStore } from '../../store/builderStore';
+import { useAnalytics } from '../../hooks/useAnalytics';
+import shopsData from '../../data/shops.json';
+import type { Shop } from '../../types/shop';
+
+const shops = shopsData as Shop[];
+
+const WRAP_LABELS: Record<string, string> = { basic: '기본 포장', ribbon: '리본 포장', premium: '프리미엄 포장' };
+const WRAP_EXTRA: Record<string, number> = { basic: 0, ribbon: 2000, premium: 5000 };
+
+const FLOWER_EMOJI: Record<string, string> = {
+  'flower-01': '🌹', 'flower-02': '🌷', 'flower-03': '🌼',
+  'flower-04': '🪷', 'flower-05': '💐', 'flower-06': '🌻',
+  'flower-07': '🌸', 'flower-08': '💜', 'flower-09': '🤍',
+  'flower-10': '🌼', 'flower-11': '🌸', 'flower-12': '💙',
+  'flower-13': '🌿', 'flower-14': '💙', 'flower-15': '🌸',
+};
+
+export default function SummaryScreen() {
+  const setScreen = useMapStore(s => s.setScreen);
+  const selectedShopId = useMapStore(s => s.selectedShopId);
+  const { flowers, wrapOption, reset } = useBuilderStore();
+  const [memo, setMemo] = useState('');
+
+  const { track } = useAnalytics();
+  const shop = shops.find(s => s.id === selectedShopId) ?? shops[0];
+  const flowerTotal = flowers.reduce((sum, f) => sum + f.unitPrice * f.quantity, 0);
+
+  useEffect(() => { track('summary_view', { shopId: shop.id, total }); }, []);
+  const wrapCost = WRAP_EXTRA[wrapOption] ?? 0;
+  const total = flowerTotal + wrapCost;
+
+  function handleCall() {
+    track('call_click', { shopId: shop.id });
+    window.location.href = `tel:${shop.phone}`;
+  }
+
+  function handleMapLink() {
+    track('map_click', { shopId: shop.id });
+    window.open(
+      `https://map.kakao.com/link/to/${encodeURIComponent(shop.name)},${shop.lat},${shop.lng}`,
+      '_blank'
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', width: '100%', height: '100dvh', background: '#faf6f7' }}>
+      {/* 헤더 */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 12,
+        padding: '16px 20px 12px', background: 'var(--white)',
+        borderBottom: '1px solid var(--border)', flexShrink: 0,
+      }}>
+        <button
+          onClick={() => setScreen('builder')}
+          style={{
+            width: 36, height: 36, borderRadius: 10,
+            border: '1.5px solid var(--border)', background: 'transparent',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            cursor: 'pointer', fontSize: 18, color: 'var(--ink2)',
+          }}
+        >←</button>
+        <div style={{
+          fontFamily: 'var(--ff-kr)', fontSize: 17, fontWeight: 700,
+          color: 'var(--ink)', letterSpacing: '-0.5px',
+        }}>꽃다발 요약</div>
+      </div>
+
+      {/* 스크롤 영역 */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: '20px 20px 0' }}>
+
+        {/* 꽃집 정보 카드 */}
+        <div style={{
+          background: 'var(--white)', borderRadius: 16,
+          border: '1.5px solid var(--border)', padding: 16, marginBottom: 16,
+          display: 'flex', alignItems: 'center', gap: 12,
+        }}>
+          <div style={{
+            width: 48, height: 48, borderRadius: 13, flexShrink: 0,
+            background: 'var(--rose-light)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 22,
+          }}>🌸</div>
+          <div style={{ flex: 1 }}>
+            <div style={{ fontFamily: 'var(--ff-kr)', fontWeight: 700, fontSize: 15, color: 'var(--ink)' }}>
+              {shop.name}
+            </div>
+            <div style={{ fontFamily: 'var(--ff-kr)', fontSize: 12, color: 'var(--muted)', marginTop: 2 }}>
+              📍 {shop.dist} · {shop.businessHours}
+            </div>
+          </div>
+        </div>
+
+        {/* 꽃 목록 */}
+        <div style={{
+          background: 'var(--white)', borderRadius: 16,
+          border: '1.5px solid var(--border)', padding: 16, marginBottom: 16,
+        }}>
+          <div style={{
+            fontFamily: 'var(--ff-kr)', fontSize: 13, fontWeight: 700,
+            color: 'var(--muted)', marginBottom: 14,
+          }}>선택한 꽃</div>
+
+          {flowers.map(f => (
+            <div key={f.flowerId} style={{
+              display: 'flex', alignItems: 'center', gap: 12,
+              paddingBottom: 12, marginBottom: 12,
+              borderBottom: '1px solid var(--border)',
+            }}>
+              <div style={{
+                width: 44, height: 44, borderRadius: 12, flexShrink: 0,
+                background: 'var(--rose-light)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 22,
+              }}>
+                {FLOWER_EMOJI[f.flowerId] ?? '🌸'}
+              </div>
+              <div style={{ flex: 1 }}>
+                <div style={{ fontFamily: 'var(--ff-kr)', fontWeight: 700, fontSize: 14, color: 'var(--ink)' }}>
+                  {f.name}
+                </div>
+                <div style={{ fontFamily: 'var(--ff-kr)', fontSize: 12, color: 'var(--muted)', marginTop: 2 }}>
+                  {f.quantity}송이 · ₩{f.unitPrice.toLocaleString()}/송이
+                </div>
+              </div>
+              <div style={{ fontFamily: 'var(--ff-en)', fontSize: 14, fontWeight: 700, color: 'var(--ink)' }}>
+                ₩{(f.unitPrice * f.quantity).toLocaleString()}
+              </div>
+            </div>
+          ))}
+
+          {/* 포장 */}
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', paddingTop: 4 }}>
+            <span style={{ fontFamily: 'var(--ff-kr)', fontSize: 13, color: 'var(--ink2)' }}>
+              {WRAP_LABELS[wrapOption]}
+            </span>
+            <span style={{ fontFamily: 'var(--ff-en)', fontSize: 13, fontWeight: 600, color: 'var(--ink2)' }}>
+              {wrapCost === 0 ? '무료' : `+₩${wrapCost.toLocaleString()}`}
+            </span>
+          </div>
+        </div>
+
+        {/* 합계 */}
+        <div style={{
+          background: 'var(--rose-light)', borderRadius: 16,
+          border: '1.5px solid var(--rose-mid)', padding: '14px 16px', marginBottom: 16,
+          display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+        }}>
+          <span style={{ fontFamily: 'var(--ff-kr)', fontSize: 14, fontWeight: 700, color: 'var(--rose)' }}>
+            예상 합계
+          </span>
+          <span style={{ fontFamily: 'var(--ff-en)', fontSize: 22, fontWeight: 700, color: 'var(--rose)' }}>
+            ₩{total.toLocaleString()}
+          </span>
+        </div>
+
+        {/* 메모 */}
+        <div style={{
+          background: 'var(--white)', borderRadius: 16,
+          border: '1.5px solid var(--border)', padding: 16, marginBottom: 16,
+        }}>
+          <div style={{
+            fontFamily: 'var(--ff-kr)', fontSize: 13, fontWeight: 700,
+            color: 'var(--muted)', marginBottom: 10,
+          }}>꽃집에 전달할 메모</div>
+          <textarea
+            value={memo}
+            onChange={e => setMemo(e.target.value)}
+            placeholder="예: 리본 핑크색으로 해주세요, 카드에 '생일 축하해'라고 적어주세요"
+            rows={3}
+            style={{
+              width: '100%', padding: '10px 12px', borderRadius: 10,
+              border: '1.5px solid var(--border)', background: '#faf6f7',
+              fontFamily: 'var(--ff-kr)', fontSize: 13, color: 'var(--ink)',
+              resize: 'none', boxSizing: 'border-box', outline: 'none', lineHeight: 1.6,
+            }}
+          />
+        </div>
+
+        <div style={{ height: 100 }} />
+      </div>
+
+      {/* 하단 CTA */}
+      <div style={{
+        padding: '12px 20px 24px', background: 'var(--white)',
+        borderTop: '1px solid var(--border)', flexShrink: 0,
+        display: 'flex', flexDirection: 'column', gap: 10,
+      }}>
+        {/* 전화 + 길찾기 나란히 */}
+        <div style={{ display: 'flex', gap: 10 }}>
+          <button
+            onClick={handleCall}
+            style={{
+              flex: 1, padding: '14px 0',
+              background: 'var(--rose)', color: '#fff',
+              border: 'none', borderRadius: 16,
+              fontFamily: 'var(--ff-kr)', fontSize: 15, fontWeight: 700,
+              cursor: 'pointer',
+            }}
+          >📞 전화 연결</button>
+          <button
+            onClick={handleMapLink}
+            style={{
+              flex: 1, padding: '14px 0',
+              background: 'var(--ink)', color: '#fff',
+              border: 'none', borderRadius: 16,
+              fontFamily: 'var(--ff-kr)', fontSize: 15, fontWeight: 700,
+              cursor: 'pointer',
+            }}
+          >🗺 길찾기</button>
+        </div>
+        <button
+          onClick={() => { reset(); setScreen('map'); }}
+          style={{
+            width: '100%', padding: '11px 0',
+            background: 'transparent', color: 'var(--muted)',
+            border: '1.5px solid var(--border)', borderRadius: 16,
+            fontFamily: 'var(--ff-kr)', fontSize: 14, cursor: 'pointer',
+          }}
+        >처음부터 다시</button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/shop/ShopDetailSheet.tsx
+++ b/src/components/shop/ShopDetailSheet.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useMapStore } from '../../store/mapStore';
+import { useAnalytics } from '../../hooks/useAnalytics';
 import FlowerDetailModal from '../flower/FlowerDetailModal';
 import shopsData from '../../data/shops.json';
 import flowersData from '../../data/flowers.json';
@@ -28,8 +29,11 @@ function isOpen(businessHours: string): boolean {
 }
 
 export default function ShopDetailSheet() {
-  const { shopDetailId, setShopDetailId } = useMapStore();
+  const { shopDetailId, setShopDetailId, openBuilderWithAi } = useMapStore();
+  const { track } = useAnalytics();
   const [selectedFlower, setSelectedFlower] = useState<Flower | null>(null);
+
+  useEffect(() => { track('shop_detail_view', { shopId: shopDetailId ?? undefined }); }, []);
 
   const shop = shops.find(s => s.id === shopDetailId) ?? null;
   if (!shop) return null;
@@ -111,7 +115,9 @@ export default function ShopDetailSheet() {
           </div>
 
           {/* AI CTA */}
-          <button style={{
+          <button
+            onClick={() => { setShopDetailId(null); openBuilderWithAi(); }}
+            style={{
             width: '100%', padding: '12px 0', marginBottom: 16,
             background: 'var(--rose)', color: '#fff', border: 'none',
             borderRadius: 13, fontFamily: 'var(--ff-kr)',
@@ -135,7 +141,7 @@ export default function ShopDetailSheet() {
             {shopFlowers.map(flower => (
               <div
                 key={flower.id}
-                onClick={() => setSelectedFlower(flower)}
+                onClick={() => { setSelectedFlower(flower); track('flower_card_click', { flowerId: flower.id }); }}
                 style={{
                   background: 'var(--white)', borderRadius: 14,
                   border: '1.5px solid var(--border)', overflow: 'hidden',

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -1,0 +1,9 @@
+import { useCallback } from 'react';
+import { logEvent, type AnalyticsEvent } from '../utils/analytics';
+
+export function useAnalytics() {
+  const track = useCallback((event: AnalyticsEvent, params?: Record<string, unknown>) => {
+    logEvent(event, params);
+  }, []);
+  return { track };
+}

--- a/src/store/mapStore.ts
+++ b/src/store/mapStore.ts
@@ -1,16 +1,19 @@
 import { create } from 'zustand';
 
-export type Screen = 'map' | 'list' | 'search' | 'builder';
+export type Screen = 'map' | 'list' | 'search' | 'builder' | 'summary';
 
 interface MapStore {
   screen: Screen;
   selectedShopId: string | null;
   shopDetailId: string | null;
   mapCenter: { lat: number; lng: number };
+  builderOpenAi: boolean;
   setScreen: (screen: Screen) => void;
   setSelectedShopId: (id: string | null) => void;
   setShopDetailId: (id: string | null) => void;
   setMapCenter: (center: { lat: number; lng: number }) => void;
+  openBuilderWithAi: () => void;
+  resetBuilderOpenAi: () => void;
 }
 
 export const useMapStore = create<MapStore>((set) => ({
@@ -18,8 +21,11 @@ export const useMapStore = create<MapStore>((set) => ({
   selectedShopId: null,
   shopDetailId: null,
   mapCenter: { lat: 37.5563, lng: 126.9138 },
+  builderOpenAi: false,
   setScreen: (screen) => set({ screen }),
   setSelectedShopId: (id) => set({ selectedShopId: id }),
   setShopDetailId: (id) => set({ shopDetailId: id }),
   setMapCenter: (center) => set({ mapCenter: center }),
+  openBuilderWithAi: () => set({ screen: 'builder', builderOpenAi: true }),
+  resetBuilderOpenAi: () => set({ builderOpenAi: false }),
 }));

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,0 +1,26 @@
+export type AnalyticsEvent =
+  | 'map_open'
+  | 'marker_click'
+  | 'list_item_click'
+  | 'search_keyword'
+  | 'shop_detail_view'
+  | 'flower_card_click'
+  | 'builder_cta_click'
+  | 'flower_added'
+  | 'flower_removed'
+  | 'qty_changed'
+  | 'wrap_option_selected'
+  | 'summary_view'
+  | 'call_click'
+  | 'map_click'
+  | 'save_bouquet';
+
+export function logEvent(event: AnalyticsEvent, params?: Record<string, unknown>) {
+  const payload = { event, ts: Date.now(), ...params };
+  const stored = JSON.parse(localStorage.getItem('bloomer_analytics') ?? '[]');
+  stored.push(payload);
+  localStorage.setItem('bloomer_analytics', JSON.stringify(stored.slice(-200)));
+  if (import.meta.env.DEV) {
+    console.info('[analytics]', event, params ?? '');
+  }
+}


### PR DESCRIPTION
## Summary
- S-05 꽃다발 요약 화면 구현 (꽃 목록, 포장, 합계, 메모, 꽃집 정보 카드)
- S-06 꽃집 연결: 전화(tel: 딥링크) + 카카오맵 길찾기 URL 연동
- Groq API(llama-3.1-8b-instant)로 AI 꽃 추천 기능 구현 (BuilderScreen)
- 전체 AI 버튼 → 빌더+AI패널 자동 오픈 (`openBuilderWithAi`)
- 지도 카테고리 필터 실제 동작 (장미/튤립/부케 flowerIds 기반 필터링, AI추천→빌더)
- useAnalytics 훅 + 전체 플로우 로그 이벤트 연동 (localStorage 저장 + DEV 콘솔 출력)

## Test plan
- [ ] 지도 마커 클릭 → 하단 카드 꽃집명 변경 확인
- [ ] 카테고리 필터 (장미/튤립/부케) → 마커 & 카드 필터링 확인
- [ ] AI추천 카테고리 → 빌더 + AI패널 자동 오픈 확인
- [ ] 빌더에서 꽃 추가 → 요약 화면 이동 확인
- [ ] 요약 화면 → 전화 연결 버튼 (tel: 딥링크) 동작 확인
- [ ] 요약 화면 → 길찾기 버튼 (카카오맵) 새 탭 오픈 확인
- [ ] DevTools 콘솔에서 [analytics] 로그 이벤트 확인

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)