### PR TITLE
feat: D6 엣지케이스 처리 + 반응형 점검

### DIFF
--- a/src/components/screens/BuilderScreen.tsx
+++ b/src/components/screens/BuilderScreen.tsx
@@ -76,7 +76,11 @@ export default function BuilderScreen() {
       setOccasion('');
       setSelectedColors([]);
     } catch (e) {
-      setAiError(e instanceof Error ? e.message : '추천 실패. 다시 시도해주세요.');
+      if (!navigator.onLine) {
+        setAiError('네트워크 연결을 확인해주세요.');
+      } else {
+        setAiError(e instanceof Error ? e.message : '추천에 실패했어요. 다시 시도해주세요.');
+      }
     } finally {
       setLoading(false);
     }
@@ -206,8 +210,18 @@ export default function BuilderScreen() {
               </div>
 
               {aiError && (
-                <div style={{ color: '#e53e3e', fontFamily: 'var(--ff-kr)', fontSize: 12, marginBottom: 10 }}>
-                  {aiError}
+                <div style={{ marginBottom: 10 }}>
+                  <div style={{ color: '#e53e3e', fontFamily: 'var(--ff-kr)', fontSize: 12, marginBottom: 6 }}>
+                    {aiError}
+                  </div>
+                  <button
+                    onClick={handleAiRecommend}
+                    style={{
+                      fontFamily: 'var(--ff-kr)', fontSize: 12, fontWeight: 600,
+                      color: 'var(--rose)', background: 'transparent', border: 'none',
+                      cursor: 'pointer', padding: 0, textDecoration: 'underline',
+                    }}
+                  >↻ 다시 시도</button>
                 </div>
               )}
 

--- a/src/components/screens/ListScreen.tsx
+++ b/src/components/screens/ListScreen.tsx
@@ -137,6 +137,18 @@ export default function ListScreen() {
 
       {/* Shop list */}
       <div style={{ flex: 1, overflowY: 'auto', padding: '0 13px 12px' }}>
+        {shops.length === 0 && (
+          <div style={{
+            display: 'flex', flexDirection: 'column', alignItems: 'center',
+            justifyContent: 'center', padding: '60px 0', gap: 12,
+          }}>
+            <span style={{ fontSize: 48 }}>🌿</span>
+            <div style={{ fontFamily: 'var(--ff-kr)', fontSize: 14, color: 'var(--muted)', textAlign: 'center' }}>
+              주변에 꽃집이 없어요<br />
+              <span style={{ fontSize: 12 }}>위치를 변경하거나 나중에 다시 시도해주세요</span>
+            </div>
+          </div>
+        )}
         {shops.map(shop => (
           <div key={shop.id} onClick={() => { setShopDetailId(shop.id); track('list_item_click', { shopId: shop.id }); }} style={{
             background: 'var(--white)', borderRadius: 16,

--- a/src/components/screens/MapScreen.tsx
+++ b/src/components/screens/MapScreen.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Map, CustomOverlayMap } from 'react-kakao-maps-sdk';
 import { useMapStore } from '../../store/mapStore';
 import { useAnalytics } from '../../hooks/useAnalytics';
+import { useGeolocation } from '../../hooks/useGeolocation';
 import shopsData from '../../data/shops.json';
 import type { Shop } from '../../types/shop';
 
@@ -25,6 +26,7 @@ const SearchIcon = () => (
 export default function MapScreen() {
   const { mapCenter, setMapCenter, setSelectedShopId, setScreen, setShopDetailId, openBuilderWithAi } = useMapStore();
   const { track } = useAnalytics();
+  useGeolocation();
   const [selIdx, setSelIdx] = useState(0);
   const [selCat, setSelCat] = useState(0);
 

--- a/src/hooks/useGeolocation.ts
+++ b/src/hooks/useGeolocation.ts
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import { useMapStore } from '../store/mapStore';
+
+const SEOUL_CENTER = { lat: 37.5563, lng: 126.9138 };
+
+export function useGeolocation() {
+  const setMapCenter = useMapStore(s => s.setMapCenter);
+
+  useEffect(() => {
+    if (!navigator.geolocation) return;
+
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        setMapCenter({ lat: pos.coords.latitude, lng: pos.coords.longitude });
+      },
+      () => {
+        setMapCenter(SEOUL_CENTER);
+      },
+      { timeout: 5000 }
+    );
+  }, []);
+}


### PR DESCRIPTION
## Summary
- `useGeolocation` 훅: 위치 권한 허용 시 실제 위치로 지도 이동, 거부/미지원 시 서울 중심 폴백
- AI 추천 실패 시 `navigator.onLine` 체크 → 오프라인/서버 에러 메시지 구분 + 재시도 버튼
- ListScreen 꽃집 0개일 때 빈 상태 UI (🌿 + 안내 문구)
- iOS Safari `100dvh` 전체 적용 확인 ✅
- 꽃 0개 상태 요약 진입 방지 (disabled 버튼) 확인 ✅
- 이미지 없는 항목 emoji placeholder 처리 확인 ✅

## Test plan
- [ ] 브라우저에서 위치 권한 거부 → 지도가 서울 중심으로 유지되는지 확인
- [ ] 오프라인 상태(DevTools Network → Offline)에서 AI 추천 → "네트워크 연결을 확인해주세요" 메시지 확인
- [ ] AI 추천 실패 후 "↻ 다시 시도" 버튼 표시 확인
- [ ] 빌더에서 꽃 미선택 시 "요약 보기" 버튼 비활성화 확인

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)